### PR TITLE
fix: Apply basePath to allergy PDF link

Align with the basePath pattern used in other parts of the codebase (sponsor logos, program logos).
This ensures the allergy PDF link works correctly when the site is deployed to a subdirectory.

Co-authored-by: Yuki Natori <yu7400ki@users.noreply.github.com>

### DIFF
--- a/src/app/(routes)/programs/[title]/page.tsx
+++ b/src/app/(routes)/programs/[title]/page.tsx
@@ -123,7 +123,7 @@ export default async function ProgramDetailPage(props: PageProps) {
                 <Text as="li" key={item}>
                   {item === ALLERGY_NOTICE_TEXT ? (
                     <a
-                      href="/r8-akabanedaifes-allergy.pdf"
+                      href={`${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/r8-akabanedaifes-allergy.pdf`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className={styles.boldLink}


### PR DESCRIPTION
<!--
Pull Requestありがとうございます！
Pull Requestを作成するにあたり、以下の内容を記述してください。

Tip: ファイルをドラッグ＆ドロップすると、画像やファイルを添付できます。
-->

## ⭐️ 概要

<!--
このPull Requestで何を行なったのか、
どう変わるのかを明確かつ簡潔に記述してください。
-->

- 変更点 1
- 変更点 2
- 変更点 3

## 😎 目的

<!--
このPull Requestでなぜその変更を行なったのか、
どのような意図なのかを明確かつ簡潔に記述してください。
-->

## 📷 スクリーンショット

<!--
スクリーンショットがあれば添付してください。
-->

## 💬 関連する Issue

<!--
関連するIssueがあれば番号を記述してください。
-->

## 🖋️ 補足事項

<!--
相談したい内容や残っている課題など、
伝えたい内容があれば記述してください。
また、関連するリンクや参考資料などがあれば教えてください。
-->
